### PR TITLE
Fix --no-session flag call in aws-vault-wrapper

### DIFF
--- a/bin/aws-vault-wrapper
+++ b/bin/aws-vault-wrapper
@@ -35,5 +35,5 @@ no_session_flag=""
 if [[ -n ${AWS_VAULT:-} || -n ${AWS_VAULT_WRAPPER_DISABLE:-} ]]; then
     exec "$cmd" "$@"  # run without aws-vault
 else
-    exec aws-vault $debug_flag $no_session_flag exec --assume-role-ttl=1h "$AWS_PROFILE" -- "$cmd" "$@"
+    exec aws-vault $debug_flag exec $no_session_flag --assume-role-ttl=1h "$AWS_PROFILE" -- "$cmd" "$@"
 fi


### PR DESCRIPTION
The no-session flag needs to be applied after the exec argument otherwise,  aws-vault will error with
```
    aws-vault: error: unknown long flag '--no-session', try --help
```