### PR TITLE
Fixing GuardDuty config, minor formatting fixes

### DIFF
--- a/orgname-id/admin-global/main.tf
+++ b/orgname-id/admin-global/main.tf
@@ -32,16 +32,3 @@ module "config" {
   check_cloud_trail_log_file_validation = true
   check_multi_region_cloud_trail        = true
 }
-
-#
-# GuardDuty
-#
-
-resource "aws_guardduty_detector" "member" {
-  enable = true
-}
-
-resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = aws_guardduty_detector.member.id
-  master_account_id = var.account_id_org_root
-}

--- a/orgname-infra/admin-global/guardduty.tf
+++ b/orgname-infra/admin-global/guardduty.tf
@@ -1,0 +1,116 @@
+# Because this account is the GuardDuty admin account (see the configs
+# in orgname-org-root/admin-global/main.tf), most of the GuardDuty
+# configuration is done here, and all findings are consolidated in this
+# account as well.
+
+# GuardDuty is a region-based service, so for each region we want to get
+# GuardDuty notifications for, we need to set up a set of resources.
+
+# The detector is the main component of GuardDuty -- this is what actually
+# "turns it on" for an account. We only need to create a detector here in
+# the GuardDuty admin account; other accounts will get detectors created
+# automatically when we add them as members later.
+
+resource "aws_guardduty_detector" "main_uswest2" {
+  enable = true
+}
+
+resource "aws_guardduty_detector" "main_useast1" {
+  provider = aws.us-east-1
+
+  enable = true
+}
+
+# The organization configuration is what links other accounts in the
+# organization to this one -- this is done by linking detectors in
+# the other accounts to this one. Note the `auto_enable = true` option
+# means than any *new* accounts we create will automatically be added
+# as members, but accounts we created prior to setting up GuardDuty for
+# the organization will need to be added manually.
+
+resource "aws_guardduty_organization_configuration" "main_uswest2" {
+  auto_enable = true
+  detector_id = aws_guardduty_detector.main_uswest2.id
+}
+
+resource "aws_guardduty_organization_configuration" "main_useast1" {
+  provider = aws.us-east-1
+
+  auto_enable = true
+  detector_id = aws_guardduty_detector.main_useast1.id
+}
+
+# This module directs GuardDuty notifications to Slack and/or PagerDuty;
+# we're going to just send them to Slack here, but they *should* be
+# infrequent enough that you could send them to PagerDuty without adding
+# too much of a burden on your on-call team.
+
+module "guardduty_notifications_uswest2" {
+  source  = "trussworks/guardduty-notifications/aws"
+  version = "~> 3.0.1"
+
+  pagerduty_notifications = false
+
+  sns_topic_slack = aws_sns_topic.notify_slack_uswest2
+}
+
+module "guardduty_notifications_useast1" {
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  source  = "trussworks/guardduty-notifications/aws"
+  version = "~> 3.0.1"
+
+  pagerduty_notifications = false
+
+  sns_topic_slack = aws_sns_topic.notify_slack_useast1
+}
+
+# Because we already created our org-root and id accounts before we created
+# the infra account and set up GuardDuty, we have to add them to the
+# GuardDuty configuration as members. However, since we created the sandbox
+# and prod accounts *after* the infra account and after we set up our
+# GuardDuty configuration, they got added to the GuardDuty configuration
+# automatically.
+
+# To add the accounts we already have, we need the following resources to
+# be defined, but due to a bug in the AWS Terraform provider, it will try to
+# destroy and then recreate them every time we run Terraform in this namespace.
+# So instead, we comment these out after the first run. This will not actually
+# remove them as members (you can confirm that with the AWS commands).
+# See https://github.com/terraform-providers/terraform-provider-aws/issues/13906
+
+# resource "aws_guardduty_member" "orgname_org_root_uswest2" {
+#   account_id                 = var.account_id_org_root
+#   detector_id                = aws_guardduty_detector.main_uswest2
+#   email                      = var.email_org_root
+#   invite                     = false
+#   disable_email_notification = true
+# }
+
+# resource "aws_guardduty_member" "orgname_org_root_useast1" {
+#   provider                   = aws.us-east-1
+#   account_id                 = var.account_id_org_root
+#   detector_id                = aws_guardduty_detector.main_useast1
+#   email                      = var.email_org_root
+#   invite                     = false
+#   disable_email_notification = true
+# }
+
+# resource "aws_guardduty_member" "orgname_id_uswest2" {
+#   account_id                 = var.account_id_id
+#   detector_id                = aws_guardduty_detector.main_uswest2
+#   email                      = var.email_id
+#   invite                     = false
+#   disable_email_notification = true
+# }
+
+# resource "aws_guardduty_member" "orgname_id_useast1" {
+#   provider                   = aws.us-east-1
+#   account_id                 = var.account_id_id
+#   detector_id                = aws_guardduty_detector.main_useast1
+#   email                      = var.email_id
+#   invite                     = false
+#   disable_email_notification = true
+# }

--- a/orgname-infra/admin-global/main.tf
+++ b/orgname-infra/admin-global/main.tf
@@ -33,19 +33,6 @@ module "config" {
   check_multi_region_cloud_trail        = true
 }
 
-#
-# GuardDuty
-#
-
-resource "aws_guardduty_detector" "member" {
-  enable = true
-}
-
-resource "aws_guardduty_invite_accepter" "member" {
-  detector_id       = aws_guardduty_detector.member.id
-  master_account_id = var.account_id_org_root
-}
-
 # This module allows the users from the id account to assume the infra
 # role in this account. See the README for more details at
 # https://github.com/trussworks/terraform-aws-iam-cross-acct-dest

--- a/orgname-infra/admin-global/slack.tf
+++ b/orgname-infra/admin-global/slack.tf
@@ -1,0 +1,188 @@
+# This SSM parameter contains our Slack webhook URL that we've added
+# manually so that it can be safely pulled here; it's a secret, so we
+# don't want to leave it in code anywhere.
+
+data "aws_ssm_parameter" "slack_webhook_url" {
+  name = "/slack/webhook/url/orgname-infra"
+}
+
+#
+# IAM
+#
+
+# These policies allow AWS resources to write to the SNS topic we use
+# for Slack notifications, and we attach these to the respective SNS
+# topics. We need one in each region because services in a region can
+# really only add messages to topics in their region.
+
+data "aws_iam_policy_document" "notify_slack_topic_policy_useast1" {
+
+  statement {
+    sid = "__default_statement_ID"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [data.aws_caller_identity.current.account_id]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_sns_topic.notify_slack_useast1.arn
+    ]
+  }
+
+  statement {
+    sid    = "allow-cloudwatch"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["SNS:Publish"]
+    resources = [aws_sns_topic.notify_slack_useast1.arn]
+  }
+}
+
+data "aws_iam_policy_document" "notify_slack_topic_policy_uswest2" {
+
+  statement {
+    sid = "__default_statement_ID"
+
+    actions = [
+      "SNS:Subscribe",
+      "SNS:SetTopicAttributes",
+      "SNS:RemovePermission",
+      "SNS:Receive",
+      "SNS:Publish",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:AddPermission",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceOwner"
+
+      values = [data.aws_caller_identity.current.account_id]
+    }
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      aws_sns_topic.notify_slack_uswest2.arn
+    ]
+  }
+
+  statement {
+    sid    = "allow-cloudwatch"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com"]
+    }
+
+    actions   = ["SNS:Publish"]
+    resources = [aws_sns_topic.notify_slack_uswest2.arn]
+  }
+}
+
+#
+# SNS
+#
+
+# These two SNS topics are the bridge between AWS services and our Slack
+# server. Note that we're attaching the policies we defined above.
+
+resource "aws_sns_topic_policy" "notify_slack_useast1" {
+  provider = aws.us-east-1
+
+  arn = aws_sns_topic.notify_slack_useast1.arn
+
+  policy = data.aws_iam_policy_document.notify_slack_topic_policy_useast1.json
+}
+
+resource "aws_sns_topic_policy" "notify_slack_uswest2" {
+  arn = aws_sns_topic.notify_slack_uswest2.arn
+
+  policy = data.aws_iam_policy_document.notify_slack_topic_policy_uswest2.json
+}
+
+# 2019-01-16 (dynamike) - There's a bug in the notify-slack Terraform module that
+# requires creating the SNS topic before you can create the notify-slack module.
+# https://github.com/terraform-aws-modules/terraform-aws-notify-slack/issues/46
+resource "aws_sns_topic" "notify_slack_useast1" {
+  provider = aws.us-east-1
+
+  name = "notify-slack"
+}
+
+resource "aws_sns_topic" "notify_slack_uswest2" {
+  name = "notify-slack"
+}
+
+#
+# Lambda
+#
+
+# These Lambdas consume messages from the SNS topics defined above, build
+# properly-formatted Slack messages, and then send them to webhook URL we
+# added to SSM.
+
+module "notify_slack_useast1" {
+  providers = {
+    aws = aws.us-east-1
+  }
+
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 3.1.0"
+
+  lambda_function_name = "notify_slack_useast1"
+  create_sns_topic     = false
+  sns_topic_name       = aws_sns_topic.notify_slack_useast1.name
+
+  slack_webhook_url = data.aws_ssm_parameter.slack_webhook_url.value
+  slack_channel     = "orgname-infra"
+  slack_username    = "aws-org-alerts"
+}
+
+module "notify_slack_uswest2" {
+  source  = "terraform-aws-modules/notify-slack/aws"
+  version = "~> 3.1.0"
+
+  lambda_function_name = "notify_slack_uswest2"
+  create_sns_topic     = false
+  sns_topic_name       = aws_sns_topic.notify_slack_uswest2.name
+
+  slack_webhook_url = data.aws_ssm_parameter.slack_webhook_url.value
+  slack_channel     = "orgname-infra"
+  slack_username    = "aws-org-alerts"
+}

--- a/orgname-infra/admin-global/variables.tf
+++ b/orgname-infra/admin-global/variables.tf
@@ -8,8 +8,20 @@ variable "account_id_org_root" {
   default     = "PLACEHOLDER"
 }
 
+variable "email_org_root" {
+  description = "Email address for org-root account"
+  type        = string
+  default     = "PLACEHOLDER"
+}
+
 variable "account_id_id" {
   description = "Account number for id account"
+  type        = string
+  default     = "PLACEHOLDER"
+}
+
+variable "email_id" {
+  description = "Email address for id account"
   type        = string
   default     = "PLACEHOLDER"
 }

--- a/orgname-org-root/admin-global/main.tf
+++ b/orgname-org-root/admin-global/main.tf
@@ -65,42 +65,14 @@ module "config" {
 # GuardDuty
 #
 
-resource "aws_guardduty_detector" "main" {
-  enable = true
-}
+# AWS best practice is that the GuardDuty admin account is not the org-root
+# account, but one that is reserved for infra or security use. In our
+# example here, that's the orgname-infra account. All other GuardDuty
+# configuration is done in that account. See
+# orgname-infra/admin-global/guardduty.tf for more information.
 
-resource "aws_guardduty_member" "orgname-id" {
-  account_id                 = aws_organizations_account.orgname-id.id
-  detector_id                = aws_guardduty_detector.main.id
-  email                      = aws_organizations_account.orgname-id.email
-  invite                     = true
-  invitation_message         = "please accept guardduty invitation"
-  disable_email_notification = true
-}
+resource "aws_guardduty_organization_admin_account" "main" {
+  depends_on = [aws_organizations_organization.main]
 
-resource "aws_guardduty_member" "orgname-infra" {
-  account_id                 = aws_organizations_account.orgname-infra.id
-  detector_id                = aws_guardduty_detector.main.id
-  email                      = aws_organizations_account.orgname-infra.email
-  invite                     = true
-  invitation_message         = "please accept guardduty invitation"
-  disable_email_notification = true
-}
-
-resource "aws_guardduty_member" "orgname-sandbox" {
-  account_id                 = aws_organizations_account.orgname-sandbox.id
-  detector_id                = aws_guardduty_detector.main.id
-  email                      = aws_organizations_account.orgname-sandbox.email
-  invite                     = true
-  invitation_message         = "please accept guardduty invitation"
-  disable_email_notification = true
-}
-
-resource "aws_guardduty_member" "orgname-prod" {
-  account_id                 = aws_organizations_account.orgname-prod.id
-  detector_id                = aws_guardduty_detector.main.id
-  email                      = aws_organizations_account.orgname-prod.email
-  invite                     = true
-  invitation_message         = "please accept guardduty invitation"
-  disable_email_notification = true
+  admin_account_id = aws_organization_account.orgname_infra.id
 }

--- a/orgname-org-root/admin-global/organization.tf
+++ b/orgname-org-root/admin-global/organization.tf
@@ -50,7 +50,7 @@ module "org_scps" {
 # AWS Organization Accounts
 #
 
-resource "aws_organizations_account" "orgname-id" {
+resource "aws_organizations_account" "orgname_id" {
   name      = format("%s-id", var.org_name)
   email     = format("%s+id@%s", var.org_email_alias, var.org_email_domain)
   parent_id = aws_organizations_organizational_unit.main.id
@@ -65,7 +65,7 @@ resource "aws_organizations_account" "orgname-id" {
   }
 }
 
-resource "aws_organizations_account" "orgname-infra" {
+resource "aws_organizations_account" "orgname_infra" {
   name      = format("%s-infra", var.org_name)
   email     = format("%s+infra@%s", var.org_email_alias, var.org_email_domain)
   parent_id = aws_organizations_organizational_unit.main.id
@@ -77,7 +77,7 @@ resource "aws_organizations_account" "orgname-infra" {
   }
 }
 
-resource "aws_organizations_account" "orgname-sandbox" {
+resource "aws_organizations_account" "orgname_sandbox" {
   name      = format("%s-sandbox", var.org_name)
   email     = format("%s+sandbox@%s", var.org_email_alias, var.org_email_domain)
   parent_id = aws_organizations_organizational_unit.main.id
@@ -89,7 +89,7 @@ resource "aws_organizations_account" "orgname-sandbox" {
   }
 }
 
-resource "aws_organizations_account" "orgname-prod" {
+resource "aws_organizations_account" "orgname_prod" {
   name      = format("%s-prod", var.org_name)
   email     = format("%s+prod@%s", var.org_email_alias, var.org_email_domain)
   parent_id = aws_organizations_organizational_unit.main.id

--- a/orgname-org-root/admin-global/outputs.tf
+++ b/orgname-org-root/admin-global/outputs.tf
@@ -8,20 +8,20 @@ output "aws_organizations_account_orgname_org_root_id" {
 
 output "aws_organizations_account_orgname_id_id" {
   description = "Account number for the orgname-id account"
-  value       = aws_organizations_account.orgname-id.id
+  value       = aws_organizations_account.orgname_id.id
 }
 
 output "aws_organizations_account_orgname_infra_id" {
   description = "Account number for the orgname-infra account"
-  value       = aws_organizations_account.orgname-infra.id
+  value       = aws_organizations_account.orgname_infra.id
 }
 
 output "aws_organizations_account_orgname_sandbox_id" {
   description = "Account number for the orgname-sandbox account"
-  value       = aws_organizations_account.orgname-sandbox.id
+  value       = aws_organizations_account.orgname_sandbox.id
 }
 
 output "aws_organizations_account_orgname_prod_id" {
   description = "Account number for the orgname-prod account"
-  value       = aws_organizations_account.orgname-prod.id
+  value       = aws_organizations_account.orgname_prod.id
 }

--- a/orgname-org-root/admin-global/users.tf
+++ b/orgname-org-root/admin-global/users.tf
@@ -115,5 +115,5 @@ module "billing_role_access" {
   version = "~> 1.0.3"
 
   iam_role_name     = "billing"
-  source_account_id = aws_organizations_account.orgname-id.id
+  source_account_id = aws_organizations_account.orgname_id.id
 }


### PR DESCRIPTION
This fixes the GuardDuty configuration that was here previously with the results of the exploration Rebecca and I have been doing for the last week or two. Also adds Slack notification stuff to `orgname-infra` and fixes some of the naming for account resources in the `org-root` account.