### PR TITLE
Add note about why use variables over locals for root module

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The following files are expected to be found:
 #### A Note on Variables vs Locals
 
 You'll notice that instead of defining variables for the root module
-with `localsi`, we define them in `variables.tf` with `variable` blocks.
+with `locals`, we define them in `variables.tf` with `variable` blocks.
 We do this because if you use locals, you cannot do a `terraform
 import`, which has caused us problems in the past. In addition, with
 `variable` declarations, you can also define the type and description

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The following files are expected to be found:
 #### A Note on Variables vs Locals
 
 You'll notice that instead of defining variables for the root module
-with locals, we define them in `variables.tf` with `variable` blocks.
+with `localsi`, we define them in `variables.tf` with `variable` blocks.
 We do this because if you use locals, you cannot do a `terraform
 import`, which has caused us problems in the past. In addition, with
 `variable` declarations, you can also define the type and description

--- a/README.md
+++ b/README.md
@@ -166,3 +166,12 @@ The following files are expected to be found:
    needed for a CircleCI build to run.
 * `variables.tf` — This almost always has, at minimum, a `region`
   and `environment` variable set.
+
+#### A Note on Variables vs Locals
+
+You'll notice that instead of defining variables for the root module
+with locals, we define them in `variables.tf` with `variable` blocks.
+We do this because if you use locals, you cannot do a `terraform
+import`, which has caused us problems in the past. In addition, with
+`variable` declarations, you can also define the type and description
+for the variable, which can provide additional context for human users.


### PR DESCRIPTION
After the third time trying to remember why we use `variable` blocks to define variables for the root module over `locals`, I have done the right thing and actually documented WHY we should this here.