### PR TITLE
remove enable_s3_endpoint as it has long been deprecated

### DIFF
--- a/modules/aws-example-vpc/main.tf
+++ b/modules/aws-example-vpc/main.tf
@@ -71,8 +71,6 @@ module "vpc" {
   reuse_nat_ips      = true
   external_nat_ips   = aws_eip.nat.*.id
 
-  enable_s3_endpoint = true
-
   tags = {
     Environment = var.environment
     Automation  = "Terraform"


### PR DESCRIPTION
## [Investigate `enable_s3_endpoint` variable in terraform-layout-example](https://trello.com/c/Mg7rIiIr)

Changes proposed in this pull request:

- `enable_s3_endpoint` has been removed as an input from the module `"terraform-aws-modules/vpc/aws"` so should be removed from the example layout
