### PR TITLE
Missing aws_iam_account_alias reference

### DIFF
--- a/orgname-id/admin-global/main.tf
+++ b/orgname-id/admin-global/main.tf
@@ -1,5 +1,7 @@
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_account_alias" "current" {}
+
 #
 # Logs
 #


### PR DESCRIPTION
Adds aws_iam_account_alias missing reference on main.tf

```
╷
│ Error: Reference to undeclared resource
│
│   on main.tf line 25, in module "config":
│   25:   config_name        = format("%s-config-%s", data.aws_iam_account_alias.current.account_alias, var.region)
│
│ A data resource "aws_iam_account_alias" "current" has not been declared in the root module.
```