### PR TITLE
Use default_tags only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,4 @@
+---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
@@ -23,11 +24,6 @@ repos:
           - mdformat-toc
         # mdformat fights with terraform_docs
         exclude: README.m(ark)?d(own)?
-
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.33.0
-    hooks:
-      - id: markdownlint
 
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5

--- a/modules/aws-example-ecr-repo/main.tf
+++ b/modules/aws-example-ecr-repo/main.tf
@@ -1,10 +1,6 @@
 locals {
   # Use our standard lifecycle policy if none passed in.
   policy = var.lifecycle_policy == "" ? file("${path.module}/lifecycle-policy.json") : var.lifecycle_policy
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_ecr_repository" "main" {

--- a/modules/aws-example-vpc/main.tf
+++ b/modules/aws-example-vpc/main.tf
@@ -44,12 +44,6 @@ resource "aws_eip" "nat" {
   count = var.single_nat_gateway ? 1 : 2
   vpc   = true
 
-  tags = {
-    Name        = format("nat-%s-%d", var.environment, count.index + 1)
-    Environment = var.environment
-    Automation  = "Terraform"
-  }
-
   lifecycle {
     prevent_destroy = true
   }
@@ -70,11 +64,6 @@ module "vpc" {
   single_nat_gateway = var.single_nat_gateway
   reuse_nat_ips      = true
   external_nat_ips   = aws_eip.nat.*.id
-
-  tags = {
-    Environment = var.environment
-    Automation  = "Terraform"
-  }
 }
 
 # Remove the permissiveness of the default SG that's created by AWS.
@@ -90,10 +79,5 @@ resource "aws_default_security_group" "default" {
     from_port = 3 # Destination Unreachable
     to_port   = 0
     self      = true
-  }
-
-  tags = {
-    Environment = var.environment
-    Automation  = "Terraform"
   }
 }

--- a/modules/aws-example-webapp/db.tf
+++ b/modules/aws-example-webapp/db.tf
@@ -48,12 +48,6 @@ resource "aws_security_group" "rds_sg" {
   name        = format("rds-my-webapp-%s", var.environment)
   description = format("my-webapp-%s RDS security group", var.environment)
   vpc_id      = var.vpc_id
-
-  tags = {
-    Name        = format("rds-my-webapp-%s", var.environment)
-    Automation  = "Terraform"
-    Environment = var.environment
-  }
 }
 
 resource "aws_security_group_rule" "rds_allow_ecs_app_inbound" {
@@ -158,11 +152,6 @@ module "my_webapp_db" {
   backup_window      = "09:00-12:00"
 
   backup_retention_period = var.db_backup_retention
-
-  tags = {
-    Automation  = "Terraform"
-    Environment = var.environment
-  }
 
   create_db_option_group = false
 

--- a/modules/aws-example-webapp/main.tf
+++ b/modules/aws-example-webapp/main.tf
@@ -16,12 +16,6 @@ resource "aws_acm_certificate" "acm_my_webapp" {
   domain_name       = var.domain_name
   validation_method = "DNS"
 
-  tags = {
-    Name        = var.domain_name
-    Environment = var.environment
-    Automation  = "Terraform"
-  }
-
   lifecycle {
     create_before_destroy = true
   }
@@ -171,11 +165,6 @@ resource "aws_ecs_cluster" "app_my_webapp" {
   setting {
     name  = "containerInsights"
     value = "disabled"
-  }
-
-  tags = {
-    Environment = var.environment
-    Automation  = "Terraform"
   }
 
   lifecycle {

--- a/orgname-id/admin-global/providers.tf
+++ b/orgname-id/admin-global/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-id/admin-global/users.tf
+++ b/orgname-id/admin-global/users.tf
@@ -50,30 +50,18 @@ resource "aws_iam_user" "infra_users" {
   for_each      = toset(local.infra_users)
   name          = each.value
   force_destroy = true
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_iam_user" "billing_users" {
   for_each      = toset(local.billing_users)
   name          = each.value
   force_destroy = true
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_iam_user" "engineer_users" {
   for_each      = toset(local.engineer_users)
   name          = each.value
   force_destroy = true
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 # Here we're defining the groups for the users we created above using

--- a/orgname-infra/admin-global/providers.tf
+++ b/orgname-infra/admin-global/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 # This is a special provider we use for Route53, because that service
@@ -10,6 +16,12 @@ provider "aws" {
   version = "~> 5.0"
   alias   = "us-east-1"
   region  = "us-east-1"
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-org-root/admin-global/organization.tf
+++ b/orgname-org-root/admin-global/organization.tf
@@ -59,10 +59,6 @@ resource "aws_organizations_account" "orgname_id" {
   # can give delivery/project managers access to billing data without
   # giving them full access to the org-root account.
   iam_user_access_to_billing = "ALLOW"
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_organizations_account" "orgname_infra" {
@@ -71,10 +67,6 @@ resource "aws_organizations_account" "orgname_infra" {
   parent_id = aws_organizations_organizational_unit.main.id
 
   iam_user_access_to_billing = "DENY"
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_organizations_account" "orgname_sandbox" {
@@ -83,10 +75,6 @@ resource "aws_organizations_account" "orgname_sandbox" {
   parent_id = aws_organizations_organizational_unit.main.id
 
   iam_user_access_to_billing = "DENY"
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_organizations_account" "orgname_prod" {
@@ -95,8 +83,4 @@ resource "aws_organizations_account" "orgname_prod" {
   parent_id = aws_organizations_organizational_unit.main.id
 
   iam_user_access_to_billing = "DENY"
-
-  tags = {
-    Automation = "Terraform"
-  }
 }

--- a/orgname-org-root/admin-global/providers.tf
+++ b/orgname-org-root/admin-global/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-org-root/admin-global/users.tf
+++ b/orgname-org-root/admin-global/users.tf
@@ -16,10 +16,6 @@ resource "aws_iam_user" "admins" {
   for_each      = toset(local.admin_users)
   name          = each.value
   force_destroy = true
-
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 locals {
@@ -60,9 +56,6 @@ resource "aws_iam_role" "admin" {
   name               = "admin"
   description        = "Role for organization administrators"
   assume_role_policy = data.aws_iam_policy_document.role_assume_role_policy.json
-  tags = {
-    Automation = "Terraform"
-  }
 }
 
 resource "aws_iam_role_policy_attachment" "admin_administrator_access" {

--- a/orgname-prod/admin-global/providers.tf
+++ b/orgname-prod/admin-global/providers.tf
@@ -1,12 +1,24 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "aws" {
   version = "~> 5.0"
   alias   = "us-east-1"
   region  = "us-east-1"
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-prod/app-my-webapp-prod/providers.tf
+++ b/orgname-prod/app-my-webapp-prod/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-sandbox/admin-global/providers.tf
+++ b/orgname-sandbox/admin-global/providers.tf
@@ -1,12 +1,24 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "aws" {
   version = "~> 5.0"
   alias   = "us-east-1"
   region  = "us-east-1"
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-sandbox/app-my-webapp-dev/providers.tf
+++ b/orgname-sandbox/app-my-webapp-dev/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-sandbox/app-my-webapp-experimental/providers.tf
+++ b/orgname-sandbox/app-my-webapp-experimental/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {

--- a/orgname-sandbox/app-my-webapp-global/providers.tf
+++ b/orgname-sandbox/app-my-webapp-global/providers.tf
@@ -1,6 +1,12 @@
 provider "aws" {
   version = "~> 5.0"
   region  = var.region
+
+  default_tags {
+    tags = {
+      Automation : "Terraform"
+    }
+  }
 }
 
 provider "template" {


### PR DESCRIPTION
Changes proposed in this pull request:

- Remove markdownlint hook -- it's broken, and `mdformat` is good enough.
- Remove tags from all objects.
- Add `default_tags` to all AWS providers.

We prefer to avoid tagging resources directly with generics like "Automation" now that `default_tags` handles it.
